### PR TITLE
Fix appservice hs_token validation, was changed in Synapse v1.90.0

### DIFF
--- a/src/matrix/AppService.ts
+++ b/src/matrix/AppService.ts
@@ -69,13 +69,13 @@ export default class AppService extends EventEmitter {
         res: Response,
         next: () => void,
     ): void {
-        const providedToken = req.query.access_token;
+        const providedToken = req.header('Authorization');
         if (!providedToken) {
             res.status(401).send({
                 errcode: 'M_UNKNOWN_TOKEN',
                 error: 'No token supplied',
             });
-        } else if (providedToken !== this.main.registration.hs_token) {
+        } else if (providedToken !== `Bearer ${this.main.registration.hs_token}`) {
             res.status(403).send({
                 errcode: 'M_UNKNOWN_TOKEN',
                 error: 'Bad token supplied',


### PR DESCRIPTION
Without this patch the messages flow only unidirectionally from Mattermost to Matrix after Synapse upgrade.

Synapse v1.90.0 deprecated access_token delivery via GET parameters, moved to Authorization header only.

https://github.com/element-hq/synapse/commit/0a5f4f766514b84aff84ff17dffd5301a437c797